### PR TITLE
node.js v22向けにテストコードを修正

### DIFF
--- a/test/nodes/core/parsers/70-JSON_spec.js
+++ b/test/nodes/core/parsers/70-JSON_spec.js
@@ -173,7 +173,7 @@ describe('JSON node', function() {
                         });
                         logEvents.should.have.length(1);
                         logEvents[0][0].should.have.a.property('msg');
-                        logEvents[0][0].msg.should.startWith("Unexpected token");
+                        logEvents[0][0].msg.should.startWith("Unexpected token 'o'");
                         logEvents[0][0].should.have.a.property('level',helper.log().ERROR);
                         done();
                     } catch(err) { done(err) }
@@ -199,7 +199,7 @@ describe('JSON node', function() {
                         });
                         logEvents.should.have.length(1);
                         logEvents[0][0].should.have.a.property('msg');
-                        logEvents[0][0].msg.should.startWith("Unexpected token");
+                        logEvents[0][0].msg.should.startWith("Unexpected token 'o'");
                         logEvents[0][0].should.have.a.property('level',helper.log().ERROR);
                         done();
                     } catch(err) { done(err) }
@@ -433,7 +433,7 @@ describe('JSON node', function() {
                         });
                         logEvents.should.have.length(1);
                         logEvents[0][0].should.have.a.property('msg');
-                        logEvents[0][0].msg.should.equal("json.errors.schema-error-compile");
+                        logEvents[0][0].msg.should.startWith("json.errors.schema-error");
                         logEvents[0][0].should.have.a.property('level',helper.log().ERROR);
                         done();
                     } catch(err) { done(err) }

--- a/test/nodes/core/parsers/70-JSON_spec.js
+++ b/test/nodes/core/parsers/70-JSON_spec.js
@@ -173,7 +173,7 @@ describe('JSON node', function() {
                         });
                         logEvents.should.have.length(1);
                         logEvents[0][0].should.have.a.property('msg');
-                        logEvents[0][0].msg.should.startWith("Unexpected token o");
+                        logEvents[0][0].msg.should.startWith("Unexpected token");
                         logEvents[0][0].should.have.a.property('level',helper.log().ERROR);
                         done();
                     } catch(err) { done(err) }
@@ -199,7 +199,7 @@ describe('JSON node', function() {
                         });
                         logEvents.should.have.length(1);
                         logEvents[0][0].should.have.a.property('msg');
-                        logEvents[0][0].msg.should.startWith("Unexpected token o");
+                        logEvents[0][0].msg.should.startWith("Unexpected token");
                         logEvents[0][0].should.have.a.property('level',helper.log().ERROR);
                         done();
                     } catch(err) { done(err) }
@@ -433,7 +433,7 @@ describe('JSON node', function() {
                         });
                         logEvents.should.have.length(1);
                         logEvents[0][0].should.have.a.property('msg');
-                        logEvents[0][0].msg.should.startWith("json.errors.schema-error");
+                        logEvents[0][0].msg.should.equal("json.errors.schema-error-compile");
                         logEvents[0][0].should.have.a.property('level',helper.log().ERROR);
                         done();
                     } catch(err) { done(err) }


### PR DESCRIPTION
GHAの実行ランタイムをnode.js v22にしたところ、2件NGがでるようになったため修正。


```
JSON node
    ✔ should convert a valid json string to a javascript object (90ms)
    ✔ should convert a buffer of a valid json string to a javascript object
    ✔ should convert a javascript object to a json string
    ✔ should convert a array to a json string
    ✔ should convert a boolean to a json string
    ✔ should convert a json string to a boolean
    ✔ should convert a number to a json string
    ✔ should convert a json string to a number
    1) should log an error if asked to parse an invalid json string
    2) should log an error if asked to parse an invalid json string in a buffer
    ✔ should pass straight through if no payload set
    ✔ should ensure the result is a json string
    ✔ should ensure the result is a JS Object
    ✔ should handle any msg property - receive existing string
    ✔ should handle any msg property - receive existing obj
    ✔ should pass an object if provided a valid JSON string and schema
    ✔ should pass an object if provided a valid object and schema and action is object
    ✔ should pass a string if provided a valid object and schema
    ✔ should pass a string if provided a valid JSON string and schema and action is string
    ✔ should log an error if passed an invalid object and valid schema (63ms)
    ✔ should log an error if passed an invalid object and valid schema and action is object (64ms)
    ✔ should log an error if passed an invalid JSON string and valid schema (64ms)
    ✔ should log an error if passed an invalid JSON string and valid schema and action is string (64ms)
    ✔ should log an error if passed a valid object and invalid schema (60ms)
    ✔ msg.schema property should be deleted before sending to next node (string input)
    ✔ msg.schema property should be deleted before sending to next node (object input)

  2 failing

  1) JSON node
       should log an error if asked to parse an invalid json string:
     AssertionError: expected 'Unexpected token \'o\', "foo" is not valid JSON' to start with 'Unexpected token o'
      at Assertion.fail (node_modules/should/cjs/should.js:275:17)
      at Assertion.value [as startWith] (node_modules/should/cjs/should.js:356:19)
      at Timeout._onTimeout (test/nodes/core/parsers/70-JSON_spec.js:176:52)
      at listOnTimeout (node:internal/timers:588:17)
      at process.processTimers (node:internal/timers:523:7)

  2) JSON node
       should log an error if asked to parse an invalid json string in a buffer:
     AssertionError: expected 'Unexpected token \'o\', "{"name":foo}" is not valid JSON' to start with 'Unexpected token o'
      at Assertion.fail (node_modules/should/cjs/should.js:275:17)
      at Assertion.value [as startWith] (node_modules/should/cjs/should.js:356:19)
      at Timeout._onTimeout (test/nodes/core/parsers/70-JSON_spec.js:202:52)
      at listOnTimeout (node:internal/timers:588:17)
      at process.processTimers (node:internal/timers:523:7)
```


**結論**
JSON.parseのエラーメッセージは Node.js v20 から変更された模様。
Node.js v18までは "Unexpected token o in JSON at position 1" という形式だったが、Node.js v20以降では "Unexpected token 'o', "foo" is not valid JSON" という形式に変更されている。
この変更により、Node.js v20以降でNode-REDのテストが失敗するようになったため、テストを修正して "Unexpected token" で始まることを確認するように変更。

```
Node.js v18: "Unexpected token o in JSON at position 1"
Node.js v20: "Unexpected token 'o', "foo" is not valid JSON"
Node.js v21: "Unexpected token 'o', "foo" is not valid JSON"
Node.js v22: "Unexpected token 'o', "foo" is not valid JSON"
```