### PR TITLE
ghaのバージョンを更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,20 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out node-red repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
             path: 'node-red'
       - name: Check out node-red-docker repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
             repository: 'node-red/node-red-docker'
             path: 'node-red-docker'
       - name: Check out node-red.github.io repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
             repository: 'node-red/node-red.github.io'
             path: 'node-red.github.io'
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
             node-version: '22'
       - run: node ./node-red/.github/scripts/update-node-red-docker.js

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         node-version: [22]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies


### PR DESCRIPTION
gha自体は成功するが、以下の警告が出るため修正。

```
[build (22)](https://github.com/enebular/node-red/actions/runs/16185101053/job/45689101052#step:6:8)
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```